### PR TITLE
Fix waveform arithmetic validation and integration

### DIFF
--- a/pysignalscope/scope.py
+++ b/pysignalscope/scope.py
@@ -648,9 +648,43 @@ class Scope:
         return list_return_dataset
 
     @staticmethod
+    def _validate_compatible_timebases(*channels: 'Channel') -> None:
+        """Validate channels before element-wise arithmetic operations.
+
+        Point-wise operations are only physically meaningful when every sample refers
+        to the same instant. This helper rejects malformed channels and mismatched
+        time bases instead of relying on NumPy broadcasting.
+
+        :param channels: Channels participating in an arithmetic operation
+        :type channels: Channel
+        """
+        if not channels:
+            raise ValueError("At least one channel is required.")
+
+        for channel in channels:
+            if not isinstance(channel, Channel):
+                raise TypeError("channel must be type Channel.")
+
+        reference_time = np.asarray(channels[0].time)
+        for channel in channels:
+            channel_time = np.asarray(channel.time)
+            channel_data = np.asarray(channel.data)
+            if channel_time.ndim != 1 or channel_data.ndim != 1:
+                raise ValueError("Channel.time and Channel.data must be one-dimensional.")
+            if channel_time.shape != channel_data.shape:
+                raise ValueError("Channel.time and Channel.data must have the same shape.")
+            if channel_time.shape != reference_time.shape:
+                raise ValueError("Channel time bases must have the same shape.")
+            if not np.array_equal(channel_time, reference_time):
+                raise ValueError("Channel time bases must contain identical values.")
+
+    @staticmethod
     def multiply(channel_1: 'Channel', channel_2: 'Channel', label: Optional[str] = None) -> 'Channel':
         """
         Multiply two datasets, e.g. to calculate the power from voltage and current.
+
+        The channels must use identical time bases. This prevents silently
+        multiplying samples that were acquired at different instants.
 
         :param channel_1: channel_1, e.g. voltage channel
         :type channel_1: Channel
@@ -661,11 +695,8 @@ class Scope:
         :return: Multiplication of two datasets, e.g. power from voltage and current
         :rtype: Channel
         """
-        if not isinstance(channel_1, Channel):
-            raise TypeError("channel_voltage must be type Channel.")
-        if not isinstance(channel_2, Channel):
-            raise TypeError("channel_current must be type Channel.")
-        if not isinstance(label, str) != label is not None:
+        Scope._validate_compatible_timebases(channel_1, channel_2)
+        if label is not None and not isinstance(label, str):
             raise TypeError("label must be type str or None.")
 
         channel_data = channel_1.data * channel_2.data
@@ -683,42 +714,51 @@ class Scope:
     @staticmethod
     def integrate(channel: 'Channel', label: Optional[str] = None) -> 'Channel':
         """
-        Integrate a channels signal.
+        Integrate a channel using the cumulative trapezoidal rule.
 
-        The default use-case is calculating energy loss (variable naming is for the use case to calculate
-        switch energy from power loss curve, e.g. from double-pulse measurement)
+        The default use-case is calculating energy loss from a power-loss curve,
+        e.g. a double-pulse measurement. Non-equidistant sample times are handled
+        using the actual interval between each pair of samples.
 
         :param channel: channel with power
         :type channel: Channel
         :param label: channel label (optional parameter)
         :type label: str
-        :return: returns a Channel-class, what integrates the input values
+        :return: cumulative integral as a Channel
         :rtype: Channel
         """
-        # init local variable
-        count = 0
-
         if not isinstance(channel, Channel):
             raise TypeError("channel_power must be type Channel.")
-        if not isinstance(label, str):
-            raise TypeError("label must be type str.")
-        channel_energy = np.array([])
-        timestep = channel.time[2] - channel.time[1]
-        for count, _ in enumerate(channel.time):
-            if count == 0:
-                # set first energy value to zero
-                channel_energy = np.append(channel_energy, 0)
-            else:
-                # using euler method
-                energy = (np.nan_to_num(channel.data[count]) + np.nan_to_num(channel.data[count - 1])) / 2 * timestep
-                channel_energy = np.append(channel_energy, channel_energy[-1] + energy)
+        if label is not None and not isinstance(label, str):
+            raise TypeError("label must be type str or None.")
+
+        channel_time = np.asarray(channel.time)
+        channel_data = np.asarray(channel.data)
+        if channel_time.ndim != 1 or channel_data.ndim != 1:
+            raise ValueError("Channel.time and Channel.data must be one-dimensional.")
+        if channel_time.shape != channel_data.shape:
+            raise ValueError("Channel.time and Channel.data must have the same shape.")
+        if channel_time.size < 2:
+            raise ValueError("At least two channel samples are required for integration.")
+
+        time_steps = np.diff(channel_time)
+        if np.any(time_steps <= 0):
+            raise ValueError("Channel.time must be strictly increasing.")
+
+        finite_data = np.nan_to_num(channel_data)
+        trapezoids = 0.5 * (finite_data[:-1] + finite_data[1:]) * time_steps
+        channel_energy = np.concatenate(([0.0], np.cumsum(trapezoids)))
+
         if label is None:
-            # Log missing user input
-            logging.info(f"{class_modulename} :Label was not defined. So default value is used", class_modulename)
+            logging.info(
+                f"{class_modulename} :Label was not defined. So default value is used"
+            )
             label = "Energy"
 
         # Log flow control
-        logging.debug(f"{class_modulename} :FlCtl Amount of channel data elements={count}")
+        logging.debug(
+            f"{class_modulename} :FlCtl Amount of channel data elements={len(channel_energy)}"
+        )
 
         return Channel(channel.time, channel_energy, label=label, unit='J', color=None, source=None,
                        linestyle=None, modulename=class_modulename)
@@ -737,13 +777,7 @@ class Scope:
             raise ValueError("Minimum two channel inputs necessary!")
 
         # check input type and time data points
-        for channel in channels:
-            if not isinstance(channel, Channel):
-                raise TypeError("channel must be type Channel.")
-            if channel.time.all() != channels[0].time.all():
-                raise ValueError("Can not add data. Different Channel.time length!")
-            if not (channel.time == channels[0].time).all():
-                raise ValueError("Can not add data. Different Channel.time values!")
+        Scope._validate_compatible_timebases(*channels)
 
         channel_data_result = np.zeros_like(channels[0].data)
         channel_label_result = ''
@@ -776,13 +810,7 @@ class Scope:
             raise ValueError("Minimum two channel inputs necessary!")
 
         # check input type and time data points
-        for channel in channels:
-            if not isinstance(channel, Channel):
-                raise TypeError("channel must be type Channel.")
-            if channel.time.all() != channels[0].time.all():
-                raise ValueError("Can not add data. Different Channel.time length!")
-            if not (channel.time == channels[0].time).all():
-                raise ValueError("Can not add data. Different Channel.time values!")
+        Scope._validate_compatible_timebases(*channels)
 
         channel_data_result = np.zeros_like(channels[0].data)
         channel_label_result = ''

--- a/tests/test_scope_power_operations.py
+++ b/tests/test_scope_power_operations.py
@@ -1,0 +1,112 @@
+"""Regression tests for channel arithmetic and power-energy calculations."""
+
+import numpy as np
+import numpy.testing as npt
+import pytest
+
+import pysignalscope as pss
+from pysignalscope.scope_dataclass import Channel
+
+
+def _channel(time, data, *, label=None, unit=None):
+    """Create a valid test channel."""
+    return pss.Scope.generate_channel(
+        time=np.asarray(time, dtype=float),
+        data=np.asarray(data, dtype=float),
+        label=label,
+        unit=unit,
+    )
+
+
+def test_multiply_calculates_power_and_generates_label():
+    """Voltage and current samples on the same time base produce power."""
+    voltage = _channel([0.0, 1.0, 2.0], [2.0, 3.0, 4.0], label="Voltage", unit="V")
+    current = _channel([0.0, 1.0, 2.0], [5.0, 6.0, 7.0], label="Current", unit="A")
+
+    power = pss.Scope.multiply(voltage, current)
+
+    npt.assert_allclose(power.data, [10.0, 18.0, 28.0])
+    npt.assert_array_equal(power.time, voltage.time)
+    assert power.label == "Voltage * Current"
+    assert power.unit == "W"
+
+
+@pytest.mark.parametrize(
+    "second_time",
+    [
+        [0.0, 1.0],
+        [0.0, 1.1, 2.0],
+    ],
+)
+def test_multiply_rejects_mismatched_timebases(second_time):
+    """Point-wise multiplication must not combine differently sampled channels."""
+    voltage = _channel([0.0, 1.0, 2.0], [2.0, 3.0, 4.0])
+    current = _channel(second_time, np.ones(len(second_time)))
+
+    with pytest.raises(ValueError, match="Channel time bases"):
+        pss.Scope.multiply(voltage, current)
+
+
+def test_multiply_rejects_malformed_channel_shape():
+    """Directly constructed malformed channels are rejected before broadcasting."""
+    voltage = Channel(
+        time=np.array([0.0, 1.0, 2.0]),
+        data=np.array([2.0, 3.0]),
+        label=None,
+        unit="V",
+        color=None,
+        linestyle=None,
+        source=None,
+        modulename="scope",
+    )
+    current = _channel([0.0, 1.0, 2.0], [1.0, 1.0, 1.0])
+
+    with pytest.raises(ValueError, match="must have the same shape"):
+        pss.Scope.multiply(voltage, current)
+
+
+def test_integrate_uses_actual_nonuniform_time_steps():
+    """Cumulative energy is correct for non-equidistant scope samples."""
+    power = _channel([0.0, 0.5, 2.0], [0.0, 2.0, 2.0], unit="W")
+
+    energy = pss.Scope.integrate(power)
+
+    npt.assert_allclose(energy.data, [0.0, 0.5, 3.5])
+    assert energy.label == "Energy"
+    assert energy.unit == "J"
+
+
+def test_integrate_accepts_two_samples_and_custom_label():
+    """A two-sample waveform has one valid trapezoidal interval."""
+    power = _channel([0.0, 2.0], [3.0, 3.0], unit="W")
+
+    energy = pss.Scope.integrate(power, label="Turn-on energy")
+
+    npt.assert_allclose(energy.data, [0.0, 6.0])
+    assert energy.label == "Turn-on energy"
+
+
+def test_integrate_rejects_single_sample_channel():
+    """Integration requires at least one time interval."""
+    power = _channel([0.0], [5.0], unit="W")
+
+    with pytest.raises(ValueError, match="At least two channel samples"):
+        pss.Scope.integrate(power)
+
+
+def test_integrate_rejects_non_string_label():
+    """The optional label accepts only strings or None."""
+    power = _channel([0.0, 1.0], [1.0, 1.0], unit="W")
+
+    with pytest.raises(TypeError, match="str or None"):
+        pss.Scope.integrate(power, label=123)
+
+
+@pytest.mark.parametrize("operation", [pss.Scope.add, pss.Scope.subtract])
+def test_add_and_subtract_reject_mismatched_timebases(operation):
+    """All element-wise arithmetic operations share the same safety checks."""
+    channel_1 = _channel([0.0, 1.0, 2.0], [1.0, 2.0, 3.0])
+    channel_2 = _channel([0.0, 1.1, 2.0], [4.0, 5.0, 6.0])
+
+    with pytest.raises(ValueError, match="identical values"):
+        operation(channel_1, channel_2)


### PR DESCRIPTION
## Summary

This pull request improves the numerical correctness and validation of
waveform arithmetic and integration operations.

## Changes

- Validate that channels used in addition, subtraction, and multiplication
  have matching timebases.
- Reject malformed channel data before waveform arithmetic.
- Correctly support multiplication when no custom label is provided.
- Replace constant-step integration with cumulative trapezoidal integration
  using the actual sampling intervals.
- Support nonuniformly sampled waveform data.
- Support valid two-sample integration.
- Reject time vectors that are too short or not strictly increasing.
- Add regression tests for the corrected behaviour.

## Motivation

Oscilloscope data may contain nonuniform sample intervals. Using one assumed
sample period can therefore produce inaccurate integrated energy values.

Waveform arithmetic also requires corresponding samples to represent the same
points in time. Explicit timebase validation prevents silent numerical errors
when channels are misaligned.

## Testing

Local environment:

- Windows
- Python 3.13.5
- `standard-xdrlib` installed because `xdrlib` was removed from Python 3.13

Results:

- Targeted regression tests: `10 passed`
- Complete project test suite: `97 passed, 3 warnings`
- `pycodestyle`: passed
- Ruff: `All checks passed`

The warnings are existing dependency deprecation warnings involving
`standard-xdrlib` and `findiff`; they are not failures in this change.